### PR TITLE
Add hitboxes for cables

### DIFF
--- a/src/main/java/com/emorn/bettercables/objects/blocks/cable/BlockCable.java
+++ b/src/main/java/com/emorn/bettercables/objects/blocks/cable/BlockCable.java
@@ -11,15 +11,23 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 @MethodsReturnNonnullByDefault
@@ -32,6 +40,69 @@ public class BlockCable extends BlockBase implements IHasModel
     public static final PropertyBool WEST = PropertyBool.create("west");
     public static final PropertyBool UP = PropertyBool.create("up");
     public static final PropertyBool DOWN = PropertyBool.create("down");
+
+    public static final AxisAlignedBB BASE_AABB = new AxisAlignedBB(
+        (double) 7 / 16,
+        (double) 7 / 16,
+        (double) 7 / 16,
+        1 - ((double) 7 / 16),
+        (double) 9 / 16,
+        1 - ((double) 7 / 16)
+    );
+
+    public static final AxisAlignedBB NORTH_CABLE_AABB = new AxisAlignedBB(
+        (double) 7 / 16,
+        (double) 7 / 16,
+        0,
+        (double) 9 / 16,
+        (double) 9 / 16,
+        (double) 7 / 16
+    );
+
+    public static final AxisAlignedBB EAST_CABLE_AABB = new AxisAlignedBB(
+        1,
+        (double) 7 / 16,
+        (double) 7 / 16,
+        (double) 7 / 16,
+        (double) 9 / 16,
+        (double) 9 / 16
+    );
+
+    public static final AxisAlignedBB SOUTH_CABLE_AABB = new AxisAlignedBB(
+        (double) 7 / 16,
+        (double) 7 / 16,
+        1,
+        (double) 9 / 16,
+        (double) 9 / 16,
+        (double) 7 / 16
+    );
+
+    public static final AxisAlignedBB WEST_CABLE_AABB = new AxisAlignedBB(
+        0,
+        (double) 7 / 16,
+        (double) 7 / 16,
+        (double) 7 / 16,
+        (double) 9 / 16,
+        (double) 9 / 16
+    );
+
+    public static final AxisAlignedBB UP_CABLE_AABB = new AxisAlignedBB(
+        (double) 7 / 16,
+        (double) 7 / 16,
+        (double) 7 / 16,
+        (double) 9 / 16,
+        1,
+        (double) 9 / 16
+    );
+
+    public static final AxisAlignedBB DOWN_CABLE_AABB = new AxisAlignedBB(
+        (double) 7 / 16,
+        0,
+        (double) 7 / 16,
+        (double) 9 / 16,
+        (double) 7 / 16,
+        (double) 9 / 16
+    );
 
     public BlockCable(String name)
     {
@@ -77,6 +148,67 @@ public class BlockCable extends BlockBase implements IHasModel
     public EnumBlockRenderType getRenderType(IBlockState state)
     {
         return EnumBlockRenderType.MODEL;
+    }
+
+    @Override
+    public AxisAlignedBB getBoundingBox(
+        IBlockState state,
+        IBlockAccess source,
+        BlockPos pos
+    )
+    {
+        EntityPlayer player = source instanceof World ? ((World) source).getClosestPlayer(
+            pos.getX(),
+            pos.getY(),
+            pos.getZ(),
+            10,
+            false
+        ) : null;
+        if (player == null) {
+            return BASE_AABB;
+        }
+
+        Vec3d start = player.getPositionEyes(1.0F);
+        Vec3d lookVec = player.getLook(1.0F);
+        Vec3d end = start.add(lookVec.scale(5));
+
+        IBlockState actualState = getActualState(state, source, pos);
+        List<AxisAlignedBB> allBoxes = retrieveAllBoxes(actualState);
+
+        AxisAlignedBB closestBox = BASE_AABB;
+        double closestDistance = Double.MAX_VALUE;
+
+        for (AxisAlignedBB box : allBoxes) {
+            RayTraceResult result = rayTrace(pos, start, end, box);
+            if (result != null) {
+                double distance = result.hitVec.distanceTo(start);
+                if (distance < closestDistance) {
+                    closestBox = box;
+                    closestDistance = distance;
+                }
+            }
+        }
+
+        return closestBox;
+    }
+
+    @Override
+    public void addCollisionBoxToList(
+        IBlockState state,
+        World worldIn,
+        BlockPos pos,
+        AxisAlignedBB entityBox,
+        List<AxisAlignedBB> collidingBoxes,
+        @Nullable Entity entityIn,
+        boolean isActualState
+    )
+    {
+        IBlockState actualState = getActualState(state, worldIn, pos);
+        List<AxisAlignedBB> allBoxes = retrieveAllBoxes(actualState);
+
+        for (AxisAlignedBB box : allBoxes) {
+            addCollisionBoxToList(pos, entityBox, collidingBoxes, box);
+        }
     }
 
     @Override
@@ -137,6 +269,39 @@ public class BlockCable extends BlockBase implements IHasModel
         return false;
     }
 
+    private List<AxisAlignedBB> retrieveAllBoxes(IBlockState state)
+    {
+        List<AxisAlignedBB> allBoxes = new ArrayList<>();
+
+        allBoxes.add(BASE_AABB);
+
+        if (this.hasConnection(state, NORTH)) {
+            allBoxes.add(NORTH_CABLE_AABB);
+        }
+
+        if (this.hasConnection(state, EAST)) {
+            allBoxes.add(EAST_CABLE_AABB);
+        }
+
+        if (this.hasConnection(state, SOUTH)) {
+            allBoxes.add(SOUTH_CABLE_AABB);
+        }
+
+        if (this.hasConnection(state, WEST)) {
+            allBoxes.add(WEST_CABLE_AABB);
+        }
+
+        if (this.hasConnection(state, UP)) {
+            allBoxes.add(UP_CABLE_AABB);
+        }
+
+        if (this.hasConnection(state, DOWN)) {
+            allBoxes.add(DOWN_CABLE_AABB);
+        }
+
+        return allBoxes;
+    }
+
     private boolean getConnectionType(
         IBlockAccess world,
         BlockPos pos,
@@ -146,6 +311,14 @@ public class BlockCable extends BlockBase implements IHasModel
         IBlockState neighborState = world.getBlockState(pos.offset(facing));
         Block neighborBlock = neighborState.getBlock();
 
-        return (neighborBlock instanceof BlockCable || neighborBlock instanceof BlockConnector);
+        return neighborBlock instanceof BlockConnector || neighborBlock instanceof BlockCable;
+    }
+
+    private boolean hasConnection(
+        IBlockState state,
+        PropertyBool facing
+    )
+    {
+        return state.getValue(facing).equals(true);
     }
 }


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
Implementation of a detailed hitbox system for cable blocks, featuring precise bounding boxes for the main block and six-directional connections. The system includes ray tracing functionality for player interaction detection and comprehensive entity collision handling. The changes establish a robust foundation for cable block interactions in the mod.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>