### PR TITLE
Add unit tests to NetworkManager and TileEntityConnector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 run
 build
 mcmodsrepo
+out
+logs

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2859'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.9' // For Mockito 2
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9' // For JUnit 4

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
 }
 
 version = '1.0'
-group = 'com.yourname.modid' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
+group = 'com.emorn.bettercables' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'modid'
 
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
@@ -74,6 +74,11 @@ dependencies {
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
     minecraft 'net.minecraftforge:forge:1.12.2-14.23.5.2859'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9' // For Mockito 2
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.9' // For JUnit 4
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/java/com/emorn/bettercables/objects/api/forge/blocks/connector/TileEntityConnector.java
+++ b/src/main/java/com/emorn/bettercables/objects/api/forge/blocks/connector/TileEntityConnector.java
@@ -48,7 +48,7 @@ public class TileEntityConnector extends TileEntity implements ITickable
     public void update()
     {
         // isRemote means isClient
-        if (this.world.isRemote) {
+        if (this.getWorld().isRemote) {
             return;
         }
 
@@ -97,7 +97,7 @@ public class TileEntityConnector extends TileEntity implements ITickable
         down.tick();
     }
 
-    private void exportItem(Direction direction)
+    public void exportItem(Direction direction) // todo might want to extract this to another class?
     {
         if (this.network == null || this.network.isDisabled()) {
             return;

--- a/src/test/java/com/emorn/bettercables/objects/api/forge/blocks/connector/NetworkManagerTest.java
+++ b/src/test/java/com/emorn/bettercables/objects/api/forge/blocks/connector/NetworkManagerTest.java
@@ -1,0 +1,119 @@
+package com.emorn.bettercables.objects.api.forge.blocks.connector;
+
+import com.emorn.bettercables.objects.api.forge.blocks.cable.BlockCable;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(org.powermock.modules.junit4.PowerMockRunner.class) // static mocking
+@PrepareForTest({NetworkManager.class, Block.class, ConnectorNetwork.class})
+@PowerMockIgnore({"javax.script.*", "org.apache.log4j.*", "javax.management.*"})
+public class NetworkManagerTest
+{
+    private World worldMock;
+    private BlockPos posMock;
+
+    private List<Block> neighborBlockTypes;
+    private int expectedNetworkSize;
+
+    @Before
+    public void setUp()
+    {
+        worldMock = mock(World.class);
+        posMock = new BlockPos(10, 10, 10);
+    }
+
+    @Test
+    public void oneConnectorOneCable_test()
+    {
+        this.neighborBlockTypes = Arrays.asList(mock(BlockConnector.class), mock(BlockCable.class));
+        this.expectedNetworkSize = 2;
+        this.reCalculateNetworksAround_test();
+    }
+
+    private void reCalculateNetworksAround_test()
+    {
+        BlockPos[] neighborPositions = new BlockPos[6];
+        for (int i = 0; i < 6; i++) {
+            IBlockState mockBlockState = mock(IBlockState.class);
+            Block mockBlock;
+
+            if (neighborBlockTypes.size() <= i) {
+                mockBlock = mock(Block.class);
+            } else {
+                mockBlock = neighborBlockTypes.get(i);
+            }
+
+            int x = 10;
+            int y = 10;
+            int z = 10;
+            if (i == 0) {
+                z = z - 1;
+            } else if (i == 1) {
+                x = x + 1;
+            } else if (i == 2) {
+                z = z + 1;
+            } else if (i == 3) {
+                x = x - 1;
+            } else if (i == 4) {
+                y = y + 1;
+            } else {
+                y = y - 1;
+            }
+
+            neighborPositions[i] = new BlockPos(x, y, z);
+
+            when(mockBlockState.getBlock()).thenReturn(mockBlock);
+
+            PowerMockito.when(worldMock.getBlockState(neighborPositions[i])).thenReturn(mockBlockState);
+
+            final int finalI = i;
+            PowerMockito.when(worldMock.getBlockState(argThat(pos ->
+                pos != null &&
+                    pos.getX() == neighborPositions[finalI].getX() &&
+                    pos.getY() == neighborPositions[finalI].getY() &&
+                    pos.getZ() == neighborPositions[finalI].getZ()
+            ))).thenReturn(mockBlockState);
+        }
+
+        List<ConnectorNetwork> createdNetworks = new ArrayList<>();
+
+        PowerMockito.mockStatic(ConnectorNetwork.class);
+
+        when(ConnectorNetwork.create(anyInt())).thenCallRealMethod();
+
+        when(ConnectorNetwork.create()).thenAnswer(invocation -> {
+            ConnectorNetwork network = ConnectorNetwork.create(createdNetworks.size());
+
+            createdNetworks.add(network);
+            return network;
+        });
+
+        NetworkManager.reCalculateNetworksAround(posMock, worldMock);
+
+        if (expectedNetworkSize > 0) {
+            assertEquals(expectedNetworkSize, createdNetworks.size());
+
+            // ... (rest of your assertions) ...
+        } else {
+            assertEquals(0, createdNetworks.size());
+        }
+    }
+}

--- a/src/test/java/com/emorn/bettercables/objects/api/forge/blocks/connector/TileEntityConnectorTest.java
+++ b/src/test/java/com/emorn/bettercables/objects/api/forge/blocks/connector/TileEntityConnectorTest.java
@@ -1,0 +1,292 @@
+package com.emorn.bettercables.objects.api.forge.blocks.connector;
+
+import com.emorn.bettercables.objects.api.forge.common.Direction;
+import com.emorn.bettercables.objects.application.blocks.connector.ConnectorSide;
+import com.emorn.bettercables.objects.gateway.blocks.ConnectorSettings;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({TileEntityConnector.class, TileEntity.class, ConnectorNetwork.class, ConnectorSide.class, World.class, BlockPos.class, TileEntityChest.class, IItemHandler.class, ConnectorSettings.class, ItemStack.class})
+@PowerMockIgnore({"javax.script.*", "org.apache.log4j.*", "javax.management.*"})
+public class TileEntityConnectorTest
+{
+    private TileEntityConnector tileEntityConnectorSpy;
+    private ConnectorNetwork connectorNetworkMock;
+    private World worldMock;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        tileEntityConnectorSpy = PowerMockito.spy(new TileEntityConnector());
+
+        connectorNetworkMock = mock(ConnectorNetwork.class);
+        worldMock = mock(World.class);
+
+        tileEntityConnectorSpy.setWorld(worldMock);
+        PowerMockito.whenNew(World.class).withAnyArguments().thenReturn(worldMock);
+        PowerMockito.whenNew(ConnectorNetwork.class).withAnyArguments().thenReturn(connectorNetworkMock);
+    }
+
+    @Test
+    public void update_shouldNotExportItem_whenNetworkIsNull() throws Exception
+    {
+        this.tileEntityConnectorSpy.update();
+
+        verifyPrivate(this.tileEntityConnectorSpy, times(0)).invoke("exportItem", any());
+    }
+
+    @Test
+    public void update_shouldNotExportItem_whenNetworkIsDisabled() throws Exception
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(true);
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        this.tileEntityConnectorSpy.update();
+
+        verifyPrivate(this.tileEntityConnectorSpy, times(0)).invoke("exportItem", any());
+    }
+
+    @Test
+    public void update_shouldMergeNetwork_whenNetworkIsRemoved()
+    {
+        when(this.connectorNetworkMock.isRemoved()).thenReturn(true);
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        BlockPos blockPos = mock(BlockPos.class);
+        when(this.tileEntityConnectorSpy.getPos()).thenReturn(blockPos);
+
+        this.tileEntityConnectorSpy.update();
+
+        verify(this.connectorNetworkMock, times(1)).mergeToNetwork(blockPos);
+    }
+
+    @Test
+    public void update_shouldExportItem_whenNetworkIsAvailable() throws Exception
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(false);
+        when(this.connectorNetworkMock.findNextIndex(anyInt())).thenReturn(0);
+
+        BlockPos chestPos = mock(BlockPos.class);
+        when(this.connectorNetworkMock.findInventoryPositionBy(anyInt())).thenReturn(chestPos);
+
+        TileEntityChest tileEntityChestMock = mock(TileEntityChest.class);
+        when(this.worldMock.getTileEntity(any())).thenReturn(tileEntityChestMock);
+
+        List<Integer> possibleIndex = new ArrayList<>();
+        possibleIndex.add(0);
+        possibleIndex.add(1);
+
+        List<List<Integer>> possibleIndexes = new ArrayList<>();
+        possibleIndexes.add(possibleIndex);
+
+        IItemHandler itemHandlerMock = mock(IItemHandler.class);
+        ItemStack mockItemStack = PowerMockito.mock(ItemStack.class);
+        when(mockItemStack.isEmpty())
+            .thenReturn(true);
+        when(mockItemStack.getCount())
+            .thenReturn(0);
+
+        PowerMockito.when(itemHandlerMock.extractItem(0, 1, false)).thenReturn(mockItemStack);
+        PowerMockito.when(itemHandlerMock.extractItem(1, 1, false)).thenReturn(mockItemStack);
+
+        when(tileEntityChestMock.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)).thenReturn(itemHandlerMock);
+
+
+        // Mock ConnectorSide for each direction
+        ConnectorSide northMock = mock(ConnectorSide.class);
+        when(northMock.canExport()).thenReturn(true);
+        ConnectorSide eastMock = mock(ConnectorSide.class);
+        when(eastMock.canExport()).thenReturn(true);
+        ConnectorSide southMock = mock(ConnectorSide.class);
+        when(southMock.canExport()).thenReturn(true);
+        ConnectorSide westMock = mock(ConnectorSide.class);
+        when(westMock.canExport()).thenReturn(true);
+        ConnectorSide upMock = mock(ConnectorSide.class);
+        when(upMock.canExport()).thenReturn(true);
+        ConnectorSide downMock = mock(ConnectorSide.class);
+        when(downMock.canExport()).thenReturn(true);
+
+        when(this.connectorNetworkMock.getPossibleSlots(any())).thenReturn(possibleIndexes);
+
+
+        doNothing().when(this.tileEntityConnectorSpy).markDirty();
+        this.tileEntityConnectorSpy.setExtractEnabled(true, Direction.NORTH);
+        this.tileEntityConnectorSpy.setExtractEnabled(true, Direction.EAST);
+        this.tileEntityConnectorSpy.setExtractEnabled(true, Direction.SOUTH);
+        this.tileEntityConnectorSpy.setExtractEnabled(true, Direction.WEST);
+        this.tileEntityConnectorSpy.setExtractEnabled(true, Direction.UP);
+        this.tileEntityConnectorSpy.setExtractEnabled(true, Direction.DOWN);
+
+        // Set up the spy to return the correct mocked instances
+        PowerMockito.doReturn(northMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.NORTH);
+        PowerMockito.doReturn(eastMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.EAST);
+        PowerMockito.doReturn(southMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.SOUTH);
+        PowerMockito.doReturn(westMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.WEST);
+        PowerMockito.doReturn(upMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.UP);
+        PowerMockito.doReturn(downMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.DOWN);
+
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+        this.tileEntityConnectorSpy.update();
+        this.tileEntityConnectorSpy.update();
+
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("exportItem", Direction.NORTH);
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("exportItem", Direction.EAST);
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("exportItem", Direction.SOUTH);
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("exportItem", Direction.WEST);
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("exportItem", Direction.UP);
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("exportItem", Direction.DOWN);
+    }
+
+    @Test
+    public void exportItem_shouldNotThrowError_whenChestIsNotFound()
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(false);
+        when(this.connectorNetworkMock.findNextIndex(anyInt())).thenReturn(0);
+        when(this.connectorNetworkMock.findInventoryPositionBy(anyInt())).thenReturn(null);
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        this.tileEntityConnectorSpy.exportItem(Direction.NORTH);
+
+        verify(this.worldMock, times(0)).getTileEntity(any());
+    }
+
+    @Test
+    public void exportItem_shouldNotThrowError_whenExportChestIsNotFound()
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(false);
+        when(this.connectorNetworkMock.findNextIndex(anyInt())).thenReturn(0);
+
+        BlockPos chestPos = mock(BlockPos.class);
+        when(this.connectorNetworkMock.findInventoryPositionBy(anyInt())).thenReturn(chestPos);
+
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        this.tileEntityConnectorSpy.exportItem(Direction.NORTH);
+
+        verify(this.worldMock, times(1)).getTileEntity(any());
+    }
+
+    @Test
+    public void exportItem_shouldNotThrowError_whenImportChestIsNotFound()
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(false);
+        when(this.connectorNetworkMock.findNextIndex(anyInt())).thenReturn(0);
+
+        BlockPos chestPos = mock(BlockPos.class);
+        when(this.connectorNetworkMock.findInventoryPositionBy(anyInt())).thenReturn(chestPos);
+
+        TileEntity tileEntityMock = mock(TileEntity.class);
+        when(this.worldMock.getTileEntity(any())).thenReturn(tileEntityMock);
+
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        this.tileEntityConnectorSpy.exportItem(Direction.NORTH);
+
+        verify(this.worldMock, times(1)).getTileEntity(any());
+    }
+
+    @Test
+    public void exportItem_shouldNotThrowError_whenConnectorSideIsNotFound() throws Exception
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(false);
+        when(this.connectorNetworkMock.findNextIndex(anyInt())).thenReturn(0);
+
+        BlockPos chestPos = mock(BlockPos.class);
+        when(this.connectorNetworkMock.findInventoryPositionBy(anyInt())).thenReturn(chestPos);
+
+        TileEntityChest tileEntityChestMock = mock(TileEntityChest.class);
+        when(this.worldMock.getTileEntity(any())).thenReturn(tileEntityChestMock);
+
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        this.tileEntityConnectorSpy.exportItem(Direction.NORTH);
+
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("findConnectorByDirection", any());
+    }
+
+    @Test
+    public void exportItem_shouldNotFail_whenThereAreNoPossibleIndexes() throws Exception
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(false);
+        when(this.connectorNetworkMock.findNextIndex(anyInt())).thenReturn(0);
+
+        BlockPos chestPos = mock(BlockPos.class);
+        when(this.connectorNetworkMock.findInventoryPositionBy(anyInt())).thenReturn(chestPos);
+
+        TileEntityChest tileEntityChestMock = mock(TileEntityChest.class);
+        when(this.worldMock.getTileEntity(any())).thenReturn(tileEntityChestMock);
+
+        ConnectorSide connectorSideMock = mock(ConnectorSide.class);
+        PowerMockito.doReturn(connectorSideMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.NORTH);
+
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        this.tileEntityConnectorSpy.exportItem(Direction.NORTH);
+
+        verify(this.connectorNetworkMock, times(1)).getPossibleSlots(connectorSideMock);
+    }
+
+    @Test
+    public void exportItem_shouldTryToExport_whenEverythingIsAvailable() throws Exception
+    {
+        when(this.connectorNetworkMock.isDisabled()).thenReturn(false);
+        when(this.connectorNetworkMock.findNextIndex(anyInt())).thenReturn(0);
+
+        BlockPos chestPos = mock(BlockPos.class);
+        when(this.connectorNetworkMock.findInventoryPositionBy(anyInt())).thenReturn(chestPos);
+
+        TileEntityChest tileEntityChestMock = mock(TileEntityChest.class);
+        when(this.worldMock.getTileEntity(any())).thenReturn(tileEntityChestMock);
+
+        ConnectorSide connectorSideMock = mock(ConnectorSide.class);
+        PowerMockito.doReturn(connectorSideMock).when( this.tileEntityConnectorSpy, "findConnectorByDirection", Direction.NORTH);
+
+        List<Integer> possibleIndex = new ArrayList<>();
+        possibleIndex.add(0);
+        possibleIndex.add(1);
+
+        List<List<Integer>> possibleIndexes = new ArrayList<>();
+        possibleIndexes.add(possibleIndex);
+
+        when(this.connectorNetworkMock.getPossibleSlots(connectorSideMock)).thenReturn(possibleIndexes);
+
+        IItemHandler itemHandlerMock = mock(IItemHandler.class);
+        ItemStack mockItemStack = PowerMockito.mock(ItemStack.class);
+        when(mockItemStack.isEmpty())
+            .thenReturn(true);
+        when(mockItemStack.getCount())
+            .thenReturn(0);
+
+        PowerMockito.when(itemHandlerMock.extractItem(0, 1, false)).thenReturn(mockItemStack);
+        PowerMockito.when(itemHandlerMock.extractItem(1, 1, false)).thenReturn(mockItemStack);
+
+        when(tileEntityChestMock.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null)).thenReturn(itemHandlerMock);
+
+        this.tileEntityConnectorSpy.setNetwork(this.connectorNetworkMock);
+
+        this.tileEntityConnectorSpy.exportItem(Direction.NORTH);
+
+        verifyPrivate(this.tileEntityConnectorSpy, times(1)).invoke("extractItemFromChest", eq(tileEntityChestMock), eq(possibleIndex.get(0)), eq(1));
+    }
+}


### PR DESCRIPTION
<div id='description'>
<h3>Summary by Bito</h3>
This PR implements extensive unit testing infrastructure for NetworkManager and TileEntityConnector components, including test dependencies setup and comprehensive test coverage for network calculations and connector functionality. The changes encompass detailed test cases for network management, item export operations, and error handling scenarios, significantly improving the codebase's test coverage and reliability.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>