### PR TITLE
Add tooltips to all the inputs

### DIFF
--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/GuiConnector.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/GuiConnector.java
@@ -77,9 +77,11 @@ public class GuiConnector extends GuiContainer
     private static final int COPY_SLOT_RANGE_BUTTON = 29;
     private static final int COPY_ITEM_COUNT_BUTTON = 30;
     private static final int COPY_DURABILITY_BUTTON = 31;
+    private static final int TOOLTIP = 32;
 
-    private static final int FILTER_START_ID = 32;
+    private static final int FILTER_START_ID = 33;
     private ConnectorSettingsFilter filter;
+    private GuiTooltip tooltipElement;
 
     public GuiConnector(
         InventoryPlayer player,
@@ -115,6 +117,21 @@ public class GuiConnector extends GuiContainer
                 this.copyFiltersMenu(tileSettings);
             }
 
+            this.tooltipElement = new GuiTooltip(
+                TOOLTIP,
+                new GuiTooltipData(
+                    0,
+                    0,
+                    new String[]{},
+                    -1,
+                    false,
+                    -1,
+                    false,
+                    true
+                )
+            );
+
+            this.buttonList.add(this.tooltipElement);
             return;
         }
 
@@ -123,8 +140,10 @@ public class GuiConnector extends GuiContainer
             checkboxX,
             checkboxInsertY,
             "Insert",
+            new String[]{},
             tileSettings.isInsertEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
 
         GuiGear insertSettings = new GuiGear(
@@ -138,8 +157,10 @@ public class GuiConnector extends GuiContainer
             checkboxX,
             checkboxExtractY,
             "Extract",
+            new String[]{},
             tileSettings.isExtractEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
         GuiGear extractSettings = new GuiGear(
             EXTRACT_SETTINGS_ID,
@@ -152,6 +173,21 @@ public class GuiConnector extends GuiContainer
         this.buttonList.add(insertSettings);
         this.buttonList.add(extractCheckbox);
         this.buttonList.add(extractSettings);
+        this.tooltipElement = new GuiTooltip(
+            TOOLTIP,
+            new GuiTooltipData(
+                0,
+                0,
+                new String[]{},
+                -1,
+                false,
+                -1,
+                false,
+                true
+            )
+        );
+
+        this.buttonList.add(this.tooltipElement);
     }
 
     private void copyFiltersMenu(ConnectorSettings tileSettings)
@@ -161,7 +197,8 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 88,
             this.guiTop + 19,
             this.filter.isOreDictEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(oreDictionaryBox);
@@ -171,8 +208,9 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 88,
             this.guiTop + 19 + 18,
             this.filter.isNbtDataEnabled(),
-            false
-        );
+            false,
+            this::onHoverTooltip
+            );
 
         this.buttonList.add(nbtDataBox);
         GuiBlackListBox blackListBox = new GuiBlackListBox(
@@ -180,7 +218,8 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 88,
             this.guiTop + 19 + 18 + 18,
             this.filter.isBlackListEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(blackListBox);
@@ -190,8 +229,12 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 10,
             this.guiTop + 19,
             "Durability",
+            new String[]{
+                "Copy the durability percentage of the item",
+            },
             tileSettings.isDynamicTickRateEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(durability);
@@ -201,8 +244,12 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 10,
             this.guiTop + 39,
             "Slot Range",
+            new String[]{
+                "Copy the slot range of the items"
+            },
             tileSettings.isDynamicTickRateEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(slotRange);
@@ -212,8 +259,12 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 10,
             this.guiTop + 59,
             "Item count",
+            new String[]{
+                "Copy the item count"
+            },
             tileSettings.isDynamicTickRateEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(itemCount);
@@ -232,6 +283,22 @@ public class GuiConnector extends GuiContainer
         }
 
         this.settingsMenu(tileSettings);
+
+        this.tooltipElement = new GuiTooltip(
+            TOOLTIP,
+            new GuiTooltipData(
+                0,
+                0,
+                new String[]{},
+                -1,
+                false,
+                -1,
+                false,
+                true
+            )
+        );
+
+        this.buttonList.add(this.tooltipElement);
     }
 
     private void settingsMenu(ConnectorSettings tileSettings)
@@ -313,6 +380,14 @@ public class GuiConnector extends GuiContainer
         this.initGui();
     }
 
+    private void onHoverTooltip(GuiTooltipData tooltipData)
+    {
+        if (this.tooltipElement == null) {
+            return;
+        }
+        this.tooltipElement.update(tooltipData);
+    }
+
     private void drawSettings(ConnectorSettings tileSettings)
     {
         GuiCopyButton copyFiltersButton = new GuiCopyButton(
@@ -320,6 +395,7 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 155,
             this.guiTop + 3,
             this::onCopyFiltersClicked,
+            this::onHoverTooltip,
             this.isCopyFiltersOpen
         );
 
@@ -339,9 +415,14 @@ public class GuiConnector extends GuiContainer
             channelId,
             TextPosition.RIGHT,
             "Channel",
+            new String[]{
+                "Channel ID for this connector",
+                "A way to have multiple channels within the same network"
+            },
             0,
             999,
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(channelInput);
@@ -366,7 +447,8 @@ public class GuiConnector extends GuiContainer
                 OVERWRITE_CHECKBOX_ID,
                 this.guiLeft - 80,
                 this.guiTop + 5 + 18,
-                this.filter.isOverwriteEnabled()
+                this.filter.isOverwriteEnabled(),
+                this::onHoverTooltip
             );
 
             this.buttonList.add(overwriteDefaultBox);
@@ -390,8 +472,19 @@ public class GuiConnector extends GuiContainer
             this.filter.minSlotRange(),
             this.filter.maxSlotRange(),
             "Slot range",
+            new String[]{
+                "Range of slots that this filter will apply to",
+                "Starting with 0, it goes left to right, top left to bottom right",
+                "If there is no minimum slot, set it to -1",
+            },
+            new String[]{
+                "Range of slots that this filter will apply to",
+                "Starting with 0, it goes left to right, top left to bottom right",
+                "If there is no maximum slot, set it to -1",
+            },
             -1,
-            disable
+            disable,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(slotInput);
@@ -408,7 +501,8 @@ public class GuiConnector extends GuiContainer
             this.guiLeft - 80,
             this.guiTop + 100 + extraY,
             this.filter.isOreDictEnabled(),
-            disable
+            disable,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(oreDictionaryBox);
@@ -421,7 +515,8 @@ public class GuiConnector extends GuiContainer
             this.guiLeft - (80 - 18),
             this.guiTop + 100 + extraY,
             this.filter.isNbtDataEnabled(),
-            disable
+            disable,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(nbtDataBox);
@@ -434,7 +529,8 @@ public class GuiConnector extends GuiContainer
             this.guiLeft - (80 - 18 - 18),
             this.guiTop + 100 + extraY,
             this.filter.isBlackListEnabled(),
-            disable
+            disable,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(blackListBox);
@@ -449,9 +545,15 @@ public class GuiConnector extends GuiContainer
             this.filter.itemCount(),
             TextPosition.TOP,
             this.isExtractSettingsOpen ? "Min item count" : "Max item count",
+            this.isExtractSettingsOpen ? new String[]{
+                "Amount of items that stays in this inventory",
+            } : new String[]{
+                "Maximum amount of items that can be in this inventory",
+            },
             0,
             999,
-            disable
+            disable,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(itemCount);
@@ -467,7 +569,8 @@ public class GuiConnector extends GuiContainer
             this.guiTop + 65 + extraY,
             this.filter.durabilityType(),
             this.filter.durabilityPercentage(),
-            disable
+            disable,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(durability);
@@ -494,9 +597,14 @@ public class GuiConnector extends GuiContainer
             tileSettings.priority(),
             TextPosition.RIGHT,
             "Priority",
+            new String[]{
+                "Priority of this connector",
+                "Higher priority means it will be used first"
+            },
             -99,
             999,
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(priority);
@@ -512,9 +620,14 @@ public class GuiConnector extends GuiContainer
             tileSettings.tickRate(),
             TextPosition.RIGHT,
             "Tick rate",
+            new String[]{
+                "Tick rate of this connector",
+                "How often it will try to extract items"
+            },
             1,
             999,
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(tickRate);
@@ -525,8 +638,12 @@ public class GuiConnector extends GuiContainer
             this.guiLeft + 180,
             this.guiTop + 35,
             "Dynamic",
+            new String[]{
+                "Enable dynamic tick rate",
+            },
             tileSettings.isDynamicTickRateEnabled(),
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(dynamic);
@@ -541,8 +658,21 @@ public class GuiConnector extends GuiContainer
             tileSettings.dynamicTickRateMinimum(),
             tileSettings.dynamicTickRateMaximum(),
             "Dynamic range",
+            new String[]{
+                "Dynamic tick rate range",
+                "Minimum and maximum tick rate that this connector will use",
+                "If dynamic is enabled, it will use this range to determine the tick rate",
+                "It determines the tick rate based on how fast it has to try to extract items",
+            },
+            new String[]{
+                "Dynamic tick rate range",
+                "Minimum and maximum tick rate that this connector will use",
+                "If dynamic is enabled, it will use this range to determine the tick rate",
+                "It determines the tick rate based on how fast it has to try to extract items",
+            },
             1,
-            !dynamic.isChecked()
+            !dynamic.isChecked(),
+            this::onHoverTooltip
         );
 
         this.buttonList.add(dynamicRange);
@@ -556,7 +686,8 @@ public class GuiConnector extends GuiContainer
             EXTRACT_TYPE_BUTTON_ID,
             this.guiLeft + 180,
             this.guiTop + 95,
-            tileSettings.extractType()
+            tileSettings.extractType(),
+            this::onHoverTooltip
         );
 
         this.buttonList.add(extractType);
@@ -568,9 +699,13 @@ public class GuiConnector extends GuiContainer
             tileSettings.itemsPerExtract(),
             TextPosition.TOP,
             "Items per action",
+            new String[]{
+                "How many items will be extracted per action",
+            },
             1,
             999,
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(itemsPerExtract);
@@ -583,9 +718,15 @@ public class GuiConnector extends GuiContainer
             tileSettings.powerSavingsSlotDisableTicks(),
             TextPosition.TOP,
             "Power savings",
+            new String[]{
+                "When it cannot extract from a given slot,",
+                "it will wait for x amount of ticks to enable again",
+                "-1 means that it will never disable the slot"
+            },
             -1,
             999,
-            false
+            false,
+            this::onHoverTooltip
         );
 
         this.buttonList.add(powerSaving);

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiCopyButton.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiCopyButton.java
@@ -15,20 +15,26 @@ public class GuiCopyButton extends net.minecraft.client.gui.GuiButton
     private static final ResourceLocation TEXTURES = new ResourceLocation(
         Reference.MODID + ":textures/gui/gui_elements.png"
     );
+    private static final int WIDTH_OF_IMAGE = 18;
+    private static final int HEIGHT_OF_IMAGE = 18;
 
     private final Consumer<Integer> callback;
+    private final Consumer<GuiTooltipData> callbackTooltip;
     private final boolean isOpen;
+    private boolean wasCursorOverInputBox = false;
 
     public GuiCopyButton(
         int buttonId,
         int x,
         int y,
         Consumer<Integer> callback,
+        Consumer<GuiTooltipData> callbackTooltip,
         boolean isOpen
     )
     {
-        super(buttonId, x, y, 18, 18, "copy");
+        super(buttonId, x, y, WIDTH_OF_IMAGE, HEIGHT_OF_IMAGE, "copy");
         this.callback = callback;
+        this.callbackTooltip = callbackTooltip;
         this.isOpen = isOpen;
     }
 
@@ -44,6 +50,45 @@ public class GuiCopyButton extends net.minecraft.client.gui.GuiButton
             return;
         }
         setupRenderState(mc);
+
+        boolean isCursorOverInputBox = this.isMouseOverInputBox(mouseX, mouseY);
+
+        GuiTooltipData guiTooltipData = new GuiTooltipData(
+            this.x,
+            this.y + 1000,
+            new String[]{
+                "Copy the values from the connected input, to these settings"
+            },
+            0,
+            false,
+            0,
+            false,
+            false
+        );
+
+        if (isCursorOverInputBox) {
+            this.callbackTooltip.accept(
+                guiTooltipData
+            );
+        } else if (this.wasCursorOverInputBox) {
+            guiTooltipData.setDisabled();
+            this.callbackTooltip.accept(
+                guiTooltipData
+            );
+        }
+
+        this.wasCursorOverInputBox = isCursorOverInputBox;
+    }
+
+    private boolean isMouseOverInputBox(
+        int mouseX,
+        int mouseY
+    )
+    {
+        return
+            (mouseX > this.x && mouseX < this.x + WIDTH_OF_IMAGE) &&
+                (mouseY > this.y && mouseY < this.y + HEIGHT_OF_IMAGE)
+            ;
     }
 
     private void setupRenderState(net.minecraft.client.Minecraft mc)

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiDurability.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiDurability.java
@@ -5,6 +5,7 @@ import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.client.gui.GuiButton;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -21,7 +22,8 @@ public class GuiDurability extends GuiButton implements AbleToChangeDisabledStat
         int y,
         ComparisonOperator comparisonOperator,
         int initialValue,
-        boolean disable
+        boolean disable,
+        Consumer<GuiTooltipData> callback
     )
     {
         super(buttonId, x, y, WIDTH_OF_IMAGE, HEIGHT_OF_IMAGE, "Durability");
@@ -31,10 +33,14 @@ public class GuiDurability extends GuiButton implements AbleToChangeDisabledStat
             x,
             y,
             "Durability%",
+            new String[]{
+                "Durability percentage of the item",
+            },
             comparisonOperator,
             initialValue,
             100,
-            disable
+            disable,
+            callback
         );
     }
 

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiExtractTypeButton.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiExtractTypeButton.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -16,17 +17,24 @@ public class GuiExtractTypeButton extends GuiButton
     private static final ResourceLocation TEXTURES = new ResourceLocation(
         Reference.MODID + ":textures/gui/gui_elements.png"
     );
+    private static final int WIDTH_OF_IMAGE = 18;
+    private static final int HEIGHT_OF_IMAGE = 18;
+
     private ExtractType extractType;
+    private final Consumer<GuiTooltipData> callbackTooltip;
+    private boolean wasCursorOverInputBox = false;
 
     public GuiExtractTypeButton(
         int buttonId,
         int x,
         int y,
-        ExtractType extractType
+        ExtractType extractType,
+        Consumer<GuiTooltipData> callbackTooltip
     )
     {
-        super(buttonId, x, y, 18, 18, "");
+        super(buttonId, x, y, WIDTH_OF_IMAGE, HEIGHT_OF_IMAGE, "");
         this.extractType = extractType;
+        this.callbackTooltip = callbackTooltip;
     }
 
     @Override
@@ -41,6 +49,49 @@ public class GuiExtractTypeButton extends GuiButton
             return;
         }
         setupRenderState(mc);
+
+        boolean isCursorOverInputBox = this.isMouseOverInputBox(mouseX, mouseY);
+
+        GuiTooltipData guiTooltipData = new GuiTooltipData(
+            this.x,
+            this.y + 1000,
+            new String[]{
+                "Determine where it will extract the items to",
+                "Round Robin: Extracts to the first input, then the second, and so on",
+                "Priority: Extracts to the input with the highest priority first",
+                "Closest First: Extracts to the closest input first",
+                "Furthest First: Extracts to the furthest input first"
+            },
+            0,
+            false,
+            0,
+            false,
+            false
+        );
+
+        if (isCursorOverInputBox) {
+            this.callbackTooltip.accept(
+                guiTooltipData
+            );
+        } else if (this.wasCursorOverInputBox) {
+            guiTooltipData.setDisabled();
+            this.callbackTooltip.accept(
+                guiTooltipData
+            );
+        }
+
+        this.wasCursorOverInputBox = isCursorOverInputBox;
+    }
+
+    private boolean isMouseOverInputBox(
+        int mouseX,
+        int mouseY
+    )
+    {
+        return
+            (mouseX > this.x && mouseX < this.x + WIDTH_OF_IMAGE) &&
+                (mouseY > this.y && mouseY < this.y + HEIGHT_OF_IMAGE)
+            ;
     }
 
     private void setupRenderState(net.minecraft.client.Minecraft mc)

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiNumberRangeInput.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiNumberRangeInput.java
@@ -7,6 +7,7 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -26,8 +27,11 @@ public class GuiNumberRangeInput extends GuiButton implements AbleToChangeDisabl
         int initialValueMin,
         int initialValueMax,
         String text,
+        String[] descriptionMin,
+        String[] descriptionMax,
         int minimumValue,
-        boolean disabled
+        boolean disabled,
+        Consumer<GuiTooltipData> callback
     )
     {
         super(buttonId, x, y, WIDTH_OF_IMAGE, HEIGHT_OF_IMAGE, text);
@@ -39,9 +43,11 @@ public class GuiNumberRangeInput extends GuiButton implements AbleToChangeDisabl
             initialValueMin,
             TextPosition.RIGHT,
             "Min",
+            descriptionMin,
             minimumValue,
             999,
-            disabled
+            disabled,
+            callback
         );
 
         this.maxInput = new GuiNumberInput(
@@ -51,9 +57,11 @@ public class GuiNumberRangeInput extends GuiButton implements AbleToChangeDisabl
             initialValueMax,
             TextPosition.RIGHT,
             "Max",
+            descriptionMax,
             minimumValue,
             999,
-            disabled
+            disabled,
+            callback
         );
     }
 

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiTooltip.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiTooltip.java
@@ -1,0 +1,106 @@
+package com.emorn.bettercables.api.v1_12_2.gui.elements;
+
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiButton;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.Math.min;
+import static net.minecraftforge.fml.client.config.GuiUtils.drawHoveringText;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class GuiTooltip extends GuiButton implements AbleToChangeDisabledState
+{
+    private static final int WIDTH_OF_IMAGE = 27;
+    private static final int HEIGHT_OF_IMAGE = 13;
+    private String[] description;
+    private int minimumValue;
+    private int maximumValue;
+    private boolean isDisabled;
+    private boolean hasMinimumValue;
+    private boolean hasMaximumValue;
+
+    public GuiTooltip(
+        int buttonId,
+        GuiTooltipData tooltipData
+    )
+    {
+        super(buttonId, tooltipData.positionX(), tooltipData.positionY(), WIDTH_OF_IMAGE, HEIGHT_OF_IMAGE, "");
+
+        this.update(tooltipData);
+    }
+
+    public void update(
+        GuiTooltipData tooltipData
+    ) {
+        this.description = tooltipData.description();
+        this.minimumValue = tooltipData.minimumValue();
+        this.hasMinimumValue = tooltipData.hasMinimumValue();
+        this.maximumValue = tooltipData.maximumValue();
+        this.hasMaximumValue = tooltipData.hasMaximumValue();
+        this.isDisabled = tooltipData.isDisabled();
+    }
+
+    @Override
+    public void drawButton(
+        Minecraft mc,
+        int mouseX,
+        int mouseY,
+        float partialTicks
+    )
+    {
+        if (partialTicks < 0.1) {
+            this.isDisabled = true;
+        }
+        if (!this.visible) {
+            return;
+        }
+
+        if (this.isDisabled) {
+            return;
+        }
+
+        List<String> tooltip = new ArrayList<>(Arrays.asList(this.description));
+
+        if (this.hasMinimumValue) {
+            tooltip.add("Minimum value: " + this.minimumValue);
+        }
+
+        if (this.hasMaximumValue) {
+            tooltip.add("Maximum value: " + this.maximumValue);
+        }
+
+        int tooltipWidth = 0;
+        for (String line : tooltip) {
+            int lineWidth = mc.fontRenderer.getStringWidth(line);
+            if (lineWidth > tooltipWidth) {
+                tooltipWidth = lineWidth;
+            }
+        }
+        int tooltipX = mouseX - tooltipWidth - 16;
+        if (tooltipX < 0) tooltipX = 0;
+
+        if (mouseX > mc.displayWidth / 5) {
+            tooltipX = mouseX;
+        } else {
+            tooltipWidth = min(tooltipWidth, mouseX - 16);
+        }
+
+        if (tooltipX + tooltipWidth + 16 > mc.displayWidth / 3) {
+            tooltipWidth = mc.displayWidth / 6;
+        }
+
+        drawHoveringText(tooltip, tooltipX, mouseY, mc.displayWidth, mc.displayHeight, tooltipWidth, mc.fontRenderer);
+    }
+
+    @Override
+    public void changeDisabledState(boolean disabled)
+    {
+        this.isDisabled = disabled;
+    }
+}

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiTooltipData.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiTooltipData.java
@@ -1,0 +1,85 @@
+package com.emorn.bettercables.api.v1_12_2.gui.elements;
+
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@MethodsReturnNonnullByDefault
+@ParametersAreNonnullByDefault
+public class GuiTooltipData
+{
+    private final int positionX;
+    private final int positionY;
+    private final String[] description;
+    private final int minimumValue;
+    private final boolean hasMinimumValue;
+    private final int maximumValue;
+    private final boolean hasMaximumValue;
+    private boolean isDisabled;
+
+    public GuiTooltipData(
+        int x,
+        int y,
+        String[] description,
+        int minimumValue,
+        boolean hasMinimumValue,
+        int maximumValue,
+        boolean hasMaximumValue,
+        boolean isDisabled
+    )
+    {
+        this.positionX = x;
+        this.positionY = y;
+        this.description = description;
+        this.minimumValue = minimumValue;
+        this.hasMinimumValue = hasMinimumValue;
+        this.maximumValue = maximumValue;
+        this.hasMaximumValue = hasMaximumValue;
+        this.isDisabled = isDisabled;
+    }
+
+    public int positionX()
+    {
+        return this.positionX;
+    }
+
+    public int positionY()
+    {
+        return this.positionY;
+    }
+
+    public String[] description()
+    {
+        return this.description;
+    }
+
+    public int minimumValue()
+    {
+        return this.minimumValue;
+    }
+
+    public boolean hasMinimumValue()
+    {
+        return this.hasMinimumValue;
+    }
+
+    public int maximumValue()
+    {
+        return this.maximumValue;
+    }
+
+    public boolean hasMaximumValue()
+    {
+        return this.hasMaximumValue;
+    }
+
+    public boolean isDisabled()
+    {
+        return this.isDisabled;
+    }
+
+    public void setDisabled()
+    {
+        this.isDisabled = true;
+    }
+}

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiBlackListBox.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiBlackListBox.java
@@ -1,8 +1,10 @@
 package com.emorn.bettercables.api.v1_12_2.gui.elements.toggle;
 
+import com.emorn.bettercables.api.v1_12_2.gui.elements.GuiTooltipData;
 import mcp.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -13,7 +15,8 @@ public class GuiBlackListBox extends GuiToggle
         int x,
         int y,
         boolean isChecked,
-        boolean disabled
+        boolean disabled,
+        Consumer<GuiTooltipData> callback
     )
     {
         super(
@@ -21,11 +24,17 @@ public class GuiBlackListBox extends GuiToggle
             x,
             y,
             "",
+            new String[]{
+                "BlackListBox",
+                "By default the item filters are in whitelist mode,",
+                "by enabling this option, the item filters will be in blacklist mode.",
+            },
             isChecked,
             new ToggleImagePosition(x, y, 197, 0, 18, 18),
             new ToggleImagePosition(x, y, 197 + 18, 0, 18, 18),
             new ToggleImagePosition(x, y, 197 + 18 + 18, 0, 18, 18),
-            disabled
+            disabled,
+            callback
         );
     }
 }

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiCheckbox.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiCheckbox.java
@@ -1,8 +1,10 @@
 package com.emorn.bettercables.api.v1_12_2.gui.elements.toggle;
 
+import com.emorn.bettercables.api.v1_12_2.gui.elements.GuiTooltipData;
 import mcp.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -13,8 +15,10 @@ public class GuiCheckbox extends GuiToggle
         int x,
         int y,
         String buttonText,
+        String[] description,
         boolean isChecked,
-        boolean disabled
+        boolean disabled,
+        Consumer<GuiTooltipData> callbackTooltip
     )
     {
         super(
@@ -22,11 +26,13 @@ public class GuiCheckbox extends GuiToggle
             x,
             y,
             buttonText,
+            description,
             isChecked,
             new ToggleImagePosition(x, y, 0, 0, 18, 18),
             new ToggleImagePosition(x, y, 18, 0, 18, 18),
         new ToggleImagePosition(x, y, 18, 0, 18, 18), // no disabled state
-            disabled
+            disabled,
+            callbackTooltip
         );
     }
 }

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiNbtDataBox.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiNbtDataBox.java
@@ -1,8 +1,10 @@
 package com.emorn.bettercables.api.v1_12_2.gui.elements.toggle;
 
+import com.emorn.bettercables.api.v1_12_2.gui.elements.GuiTooltipData;
 import mcp.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -13,7 +15,8 @@ public class GuiNbtDataBox extends GuiToggle
         int x,
         int y,
         boolean isChecked,
-        boolean disabled
+        boolean disabled,
+        Consumer<GuiTooltipData> callback
     )
     {
         super(
@@ -21,11 +24,17 @@ public class GuiNbtDataBox extends GuiToggle
             x,
             y,
             "",
+            new String[]{
+                "Nbt Data Box",
+                "When enabled, the filters will not only check the name of the item",
+                "but also the NBT data of the item.",
+            },
             isChecked,
             new ToggleImagePosition(x, y, 197, 36, 18, 18),
             new ToggleImagePosition(x, y, 197 + 18, 36, 18, 18),
         new ToggleImagePosition(x, y, 197 + 18 + 18, 36, 18, 18),
-        disabled
+        disabled,
+            callback
         );
     }
 }

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiOreDictionaryBox.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiOreDictionaryBox.java
@@ -1,8 +1,10 @@
 package com.emorn.bettercables.api.v1_12_2.gui.elements.toggle;
 
+import com.emorn.bettercables.api.v1_12_2.gui.elements.GuiTooltipData;
 import mcp.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -13,7 +15,8 @@ public class GuiOreDictionaryBox extends GuiToggle
         int x,
         int y,
         boolean isChecked,
-        boolean disabled
+        boolean disabled,
+        Consumer<GuiTooltipData> callback
     )
     {
         super(
@@ -21,11 +24,16 @@ public class GuiOreDictionaryBox extends GuiToggle
             x,
             y,
             "",
+            new String[]{
+                "Enables or disables ore dictionary matching for this filter.",
+                "When enabled, items matching the same ore dictionary entry will be treated as equivalent.",
+            },
             isChecked,
             new ToggleImagePosition(x, y, 197, 18, 18, 18),
             new ToggleImagePosition(x, y, 197 + 18, 18, 18, 18),
             new ToggleImagePosition(x, y, 197 + 18 + 18, 18, 18, 18),
-            disabled
+            disabled,
+            callback
         );
     }
 }

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiOverwriteDefaultBox.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiOverwriteDefaultBox.java
@@ -1,8 +1,10 @@
 package com.emorn.bettercables.api.v1_12_2.gui.elements.toggle;
 
+import com.emorn.bettercables.api.v1_12_2.gui.elements.GuiTooltipData;
 import mcp.MethodsReturnNonnullByDefault;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -12,7 +14,8 @@ public class GuiOverwriteDefaultBox extends GuiCheckbox
         int buttonId,
         int x,
         int y,
-        boolean isChecked
+        boolean isChecked,
+        Consumer<GuiTooltipData> callbackTooltip
     )
     {
         super(
@@ -20,8 +23,13 @@ public class GuiOverwriteDefaultBox extends GuiCheckbox
             x,
             y,
             "Overwrite",
+            new String[]{
+                "When disables, it will follow the settings of the connector itself",
+                "When enabled, it will overwrite all settings with the values set here",
+            },
             isChecked,
-            false
+            false,
+            callbackTooltip
         );
     }
 }

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiOverwriteDefaultBox.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiOverwriteDefaultBox.java
@@ -24,7 +24,7 @@ public class GuiOverwriteDefaultBox extends GuiCheckbox
             y,
             "Overwrite",
             new String[]{
-                "When disables, it will follow the settings of the connector itself",
+                "When disabled, it will follow the settings of the connector itself",
                 "When enabled, it will overwrite all settings with the values set here",
             },
             isChecked,

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiToggle.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiToggle.java
@@ -20,6 +20,7 @@ public class GuiToggle extends GuiButton implements AbleToChangeDisabledState
     );
     private static final int WIDTH_OF_IMAGE = 18;
     private static final int HEIGHT_OF_IMAGE = 18;
+    private static final int TOOLTIP_Y_OFFSET = 1000;
 
     private final ToggleImagePosition inactive;
     private final ToggleImagePosition active;
@@ -71,7 +72,7 @@ public class GuiToggle extends GuiButton implements AbleToChangeDisabledState
 
         GuiTooltipData guiTooltipData = new GuiTooltipData(
             this.x,
-            this.y + 1000,
+            this.y + TOOLTIP_Y_OFFSET,
             this.description,
             0,
             false,

--- a/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiToggle.java
+++ b/src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/toggle/GuiToggle.java
@@ -1,6 +1,7 @@
 package com.emorn.bettercables.api.v1_12_2.gui.elements.toggle;
 
 import com.emorn.bettercables.api.v1_12_2.gui.elements.AbleToChangeDisabledState;
+import com.emorn.bettercables.api.v1_12_2.gui.elements.GuiTooltipData;
 import com.emorn.bettercables.core.common.Reference;
 import mcp.MethodsReturnNonnullByDefault;
 import net.minecraft.client.gui.GuiButton;
@@ -8,6 +9,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
 
 @MethodsReturnNonnullByDefault
 @ParametersAreNonnullByDefault
@@ -16,30 +18,40 @@ public class GuiToggle extends GuiButton implements AbleToChangeDisabledState
     private static final ResourceLocation TEXTURES = new ResourceLocation(
         Reference.MODID + ":textures/gui/gui_elements.png"
     );
+    private static final int WIDTH_OF_IMAGE = 18;
+    private static final int HEIGHT_OF_IMAGE = 18;
+
     private final ToggleImagePosition inactive;
     private final ToggleImagePosition active;
     private final ToggleImagePosition disabled;
+    private final Consumer<GuiTooltipData> callbackTooltip;
     private boolean isChecked;
+    private final String[] description;
     private boolean isDisabled;
+    private boolean wasCursorOverInputBox = false;
 
     public GuiToggle(
         int buttonId,
         int x,
         int y,
         String buttonText,
+        String[] description,
         boolean isChecked,
         ToggleImagePosition inactiveTogglePosition,
         ToggleImagePosition activeTogglePosition,
         ToggleImagePosition disabledTogglePosition,
-        boolean disabled
+        boolean disabled,
+        Consumer<GuiTooltipData> callbackTooltip
     )
     {
-        super(buttonId, x, y, 18, 18, buttonText);
+        super(buttonId, x, y, WIDTH_OF_IMAGE, HEIGHT_OF_IMAGE, buttonText);
+        this.description = description;
         this.isDisabled = disabled;
         this.isChecked = isChecked;
         this.inactive = inactiveTogglePosition;
         this.active = activeTogglePosition;
         this.disabled = disabledTogglePosition;
+        this.callbackTooltip = callbackTooltip;
     }
 
     @Override
@@ -54,6 +66,43 @@ public class GuiToggle extends GuiButton implements AbleToChangeDisabledState
             return;
         }
         setupRenderState(mc);
+
+        boolean isCursorOverInputBox = this.isMouseOverInputBox(mouseX, mouseY);
+
+        GuiTooltipData guiTooltipData = new GuiTooltipData(
+            this.x,
+            this.y + 1000,
+            this.description,
+            0,
+            false,
+            0,
+            false,
+            false
+        );
+
+        if (isCursorOverInputBox) {
+            this.callbackTooltip.accept(
+                guiTooltipData
+            );
+        } else if (this.wasCursorOverInputBox) {
+            guiTooltipData.setDisabled();
+            this.callbackTooltip.accept(
+                guiTooltipData
+            );
+        }
+
+        this.wasCursorOverInputBox = isCursorOverInputBox;
+    }
+
+    private boolean isMouseOverInputBox(
+        int mouseX,
+        int mouseY
+    )
+    {
+        return
+            (mouseX > this.x && mouseX < this.x + WIDTH_OF_IMAGE) &&
+                (mouseY > this.y && mouseY < this.y + HEIGHT_OF_IMAGE)
+            ;
     }
 
     private void setupRenderState(net.minecraft.client.Minecraft mc)


### PR DESCRIPTION
This pull request enhances the `GuiConnector` class by implementing a tooltip system for improved user interaction and clarity. It introduces the `GuiTooltip` element, integrates hover-based tooltips across various GUI components, and updates button behaviors to provide contextual information dynamically.

### Tooltip System Integration:

* Added a new `GuiTooltip` element (`tooltipElement`) to the `GuiConnector` class, initialized in multiple methods (`initGui`, `onSettingsClicked`, etc.) to display dynamic tooltips. (`[[1]](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139R80-R84)`, `[[2]](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139R120-R134)`, `[[3]](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139R176-R190)`, `[[4]](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139R286-R301)`)
* Introduced the `onHoverTooltip` method to update the tooltip content dynamically based on user interactions. (`[src/main/java/com/emorn/bettercables/api/v1_12_2/gui/GuiConnector.javaR383-R398](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139R383-R398)`)

### Enhanced Button Functionality:

* Updated various buttons (e.g., checkboxes, sliders) to include hover-based tooltips, providing contextual information such as descriptions or usage instructions. Examples include "Durability", "Slot Range", and "Dynamic Tick Rate". (`[[1]](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139R232-R237)`, `[[2]](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139L369-R451)`, `[[3]](diffhunk://#diff-46554534e607c69a8ce77d9f8bbae5734e8f8486da267705e45d366f392b1139R661-R675)`)

### Code Enhancements:

* Added `Consumer` imports to support functional programming constructs for tooltip handling. (`[src/main/java/com/emorn/bettercables/api/v1_12_2/gui/elements/GuiComparisonOperatorButton.javaR11](diffhunk://#diff-37df0f5269fcd8300b67a1794c5987aabb0f6e8ae4cba44ee27bb694dad09c9aR11)`)